### PR TITLE
Create YARD DSL handlers

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require "rspec/core/rake_task"
 require "yard"
+require_relative "handlers/attribute"
 
 task :default => [:test, :check_docs]
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require "rspec/core/rake_task"
 require "yard"
-require_relative "handlers/attribute"
+
+Dir["handlers/**/*.rb"].each { |handler| require_relative handler }
 
 task :default => [:test, :check_docs]
 

--- a/handlers/attribute.rb
+++ b/handlers/attribute.rb
@@ -1,0 +1,40 @@
+module Greeve
+  module Handlers
+    # YARD handler for the `attribute` DSL method.
+    class Attribute < YARD::Handlers::Ruby::Base
+      handles method_call(:attribute)
+      namespace_only
+
+      process do
+        name = statement.parameters[0].jump(:ident).source
+
+        type =
+          statement
+            .parameters[1]
+            .jump(:assoc, :label, "type")
+            .parent
+            .jump(:ident)
+            .source
+
+        object = YARD::CodeObjects::MethodObject.new(namespace, name)
+        register(object)
+
+        object.group = "Attributes"
+
+        return_type =
+          case type
+          when "integer"
+            type.capitalize
+          when "string"
+            type.capitalize
+          when "numeric"
+            "BigDecimal"
+          when "datetime"
+            "Time"
+          end
+
+        object.add_tag(YARD::Tags::Tag.new(:return, nil, return_type))
+      end
+    end
+  end
+end

--- a/handlers/endpoint.rb
+++ b/handlers/endpoint.rb
@@ -1,0 +1,20 @@
+require_relative "../lib/greeve"
+
+module Greeve
+  module Handlers
+    # YARD handler for the `endpoint` DSL method.
+    class Endpoint < YARD::Handlers::Ruby::Base
+      handles method_call(:endpoint)
+      namespace_only
+
+      process do
+        endpoint = statement.parameters[0].jump(:tstring_content).source
+
+        namespace.add_tag(YARD::Tags::Tag.new(
+          :note,
+          "Endpoint: #{Greeve::EVE_API_BASE_URL}/#{endpoint}.xml.aspx"
+        ))
+      end
+    end
+  end
+end

--- a/handlers/rowset.rb
+++ b/handlers/rowset.rb
@@ -1,0 +1,54 @@
+module Greeve
+  module Handlers
+    # YARD handler for the `rowset` DSL method.
+    class Rowset < YARD::Handlers::Ruby::Base
+      handles method_call(:rowset)
+      namespace_only
+
+      process do
+        name = statement.parameters[0].jump(:ident).source
+        block_ast = statement.last.last
+
+        object = YARD::CodeObjects::MethodObject.new(namespace, name)
+        register(object)
+        parse_block(block_ast, owner: object)
+
+        object.group = "Attributes"
+
+        object.add_tag(YARD::Tags::Tag.new(:return, nil, "Greeve::Rowset"))
+
+        block_ast.each do |node|
+          method_name = node.first.jump(:ident).source
+
+          next unless method_name == "attribute"
+
+          attribute_name = node.parameters[0].jump(:ident).source
+
+          type =
+            node
+              .parameters[1]
+              .jump(:assoc, :label, "type")
+              .parent
+              .jump(:ident)
+              .source
+
+          attribute_type =
+            case type
+            when "integer"
+              type.capitalize
+            when "string"
+              type.capitalize
+            when "numeric"
+              "BigDecimal"
+            when "datetime"
+              "Time"
+            end
+
+          object.add_tag(
+            YARD::Tags::Tag.new(:param, nil, attribute_type, attribute_name)
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/greeve/eve/character_info.rb
+++ b/lib/greeve/eve/character_info.rb
@@ -3,6 +3,8 @@ require_relative "../base_item"
 module Greeve
   module Eve
     # Public character info.
+    #
+    # @see https://eveonline-third-party-documentation.readthedocs.io/en/latest/xmlapi/eve/eve_characterinfo.html
     class CharacterInfo < Greeve::BaseItem
       endpoint "eve/CharacterInfo"
 

--- a/lib/greeve/rowset.rb
+++ b/lib/greeve/rowset.rb
@@ -42,7 +42,7 @@ module Greeve
     # Map an XML attribute to a Ruby object.
     #
     # @!visibility private
-    # @see {Greeve::BaseItem.attribute}
+    # @see Greeve::BaseItem.attribute
     def attribute(name, opts = {})
       name = name.to_sym
 


### PR DESCRIPTION
For #15

This PR adds YARD handlers for the `attribute`, `endpoint`, and `rowset` DSL methods so that they show up in the documentation.

---

![image](https://cloud.githubusercontent.com/assets/4755047/18035251/15867970-6d07-11e6-9787-4647a89387b3.png)
