### PR TITLE
Consolidate code shared between BaseItem, Row, and Rowset

### DIFF
--- a/lib/greeve.rb
+++ b/lib/greeve.rb
@@ -4,6 +4,9 @@ require "typhoeus"
 
 require_relative "greeve/version"
 
+require_relative "greeve/helpers/add_attribute"
+require_relative "greeve/helpers/define_attribute_method"
+
 require_relative "greeve/base_item"
 require_relative "greeve/row"
 require_relative "greeve/rowset"
@@ -26,4 +29,7 @@ module Greeve
   module Map; end
   # Server resources.
   module Server; end
+
+  # A namespace containing helper modules.
+  module Helpers; end
 end

--- a/lib/greeve/helpers/add_attribute.rb
+++ b/lib/greeve/helpers/add_attribute.rb
@@ -1,0 +1,25 @@
+module Greeve
+  module Helpers
+    # Adds a helper method to add an attribute to the attributes hash instance
+    # variable.
+    module AddAttribute
+      private
+
+      # Add an attribute to the attributes hash instance variable.
+      #
+      # @param name [String] name of the attribute method
+      # @param opts [Hash] option hash passed from the attribute DSL helper method
+      def add_attribute(name, opts = {})
+        name = name.to_sym
+
+        raise "Attribute `#{name}` defined more than once" if @attributes[name]
+        raise "`:xpath` not specified for `#{name}`" unless opts[:xpath]
+
+        @attributes[name] = {
+          xpath: opts[:xpath],
+          type: opts[:type],
+        }
+      end
+    end
+  end
+end

--- a/lib/greeve/helpers/define_attribute_method.rb
+++ b/lib/greeve/helpers/define_attribute_method.rb
@@ -1,0 +1,42 @@
+module Greeve
+  module Helpers
+    # Adds a helper method to define a class or instance method for a given
+    # attribute.
+    module DefineAttributeMethod
+      private
+
+      # Define a class or instance method for a given attribute.
+      #
+      # @param scope [:class, :instance] define the attribute names as class or
+      #   instance methods
+      # @param name [String] name of the attribute method
+      # @param opts [Hash] option hash passed from the attribute DSL helper method
+      def define_attribute_method(scope, name, opts = {})
+        method = scope == :instance ? :define_singleton_method : :define_method
+
+        send(method, name) do
+          ivar = instance_variable_get(:"@#{name}")
+          return ivar unless ivar.nil?
+
+          value = @xml_element.locate(opts[:xpath]).first
+
+          unless value.nil?
+            value =
+              case opts[:type]
+              when :integer
+                value.to_i
+              when :numeric
+                BigDecimal.new(value)
+              when :string
+                value.to_s
+              when :datetime
+                Time.parse(value + " UTC")
+              end
+          end
+
+          instance_variable_set(:"@#{name}", value)
+        end
+      end
+    end
+  end
+end

--- a/lib/greeve/row.rb
+++ b/lib/greeve/row.rb
@@ -1,6 +1,10 @@
+require_relative "helpers/define_attribute_method"
+
 module Greeve
   # Represents an XML `row` element, contained in a {Rowset}.
   class Row
+    include Greeve::Helpers::DefineAttributeMethod
+
     # @param xml_element [Ox::Element] the xml row element for this item
     # @param attributes [Hash] the hash of attribute definitions for this row
     def initialize(xml_element, attributes)
@@ -8,28 +12,7 @@ module Greeve
       @attributes = attributes
 
       attributes.each do |name, opts|
-        define_singleton_method(name) do
-          ivar = instance_variable_get(:"@#{name}")
-          return ivar unless ivar.nil?
-
-          value = @xml_element.locate(opts[:xpath]).first
-
-          unless value.nil?
-            value =
-              case opts[:type]
-              when :integer
-                value.to_i
-              when :numeric
-                BigDecimal.new(value)
-              when :string
-                value.to_s
-              when :datetime
-                Time.parse(value + " UTC")
-              end
-          end
-
-          instance_variable_set(:"@#{name}", value)
-        end
+        define_attribute_method(:instance, name, opts)
       end
     end
 

--- a/lib/greeve/rowset.rb
+++ b/lib/greeve/rowset.rb
@@ -1,8 +1,10 @@
+require_relative "helpers/add_attribute"
 require_relative "row"
 
 module Greeve
   # Represents an XML `rowset` element.
   class Rowset
+    include Greeve::Helpers::AddAttribute
     include Enumerable
 
     # @return [Symbol] name of the rowset
@@ -42,18 +44,8 @@ module Greeve
     # Map an XML attribute to a Ruby object.
     #
     # @!visibility private
-    # @see Greeve::BaseItem.attribute
-    def attribute(name, opts = {})
-      name = name.to_sym
-
-      raise "Attribute `#{name}` defined more than once" if @attributes[name]
-      raise "`:xpath` not specified for `#{name}`" unless opts[:xpath]
-
-      @attributes[name] = {
-        xpath: opts[:xpath],
-        type: opts[:type],
-      }
-    end
+    # @see Greeve::Attributable#add_attribute
+    alias_method :attribute, :add_attribute
 
     private
 

--- a/spec/base_item_spec.rb
+++ b/spec/base_item_spec.rb
@@ -113,13 +113,6 @@ describe Greeve::BaseItem do
       end
     end
 
-    describe "attribute types" do
-      its(:character_id) { should be_a Integer }
-      its(:character_name) { should be_a String }
-      its(:corporation_date) { should be_a Time }
-      its(:security_status) { should be_a BigDecimal }
-    end
-
     describe "cache_expired?" do
       before {
         # Replace `cachedUntil` with a mocked value.

--- a/spec/helpers/add_attribute_spec.rb
+++ b/spec/helpers/add_attribute_spec.rb
@@ -1,0 +1,48 @@
+describe Greeve::Helpers::AddAttribute do
+  subject {
+    Class.new do
+      extend Greeve::Helpers::AddAttribute
+
+      public_class_method :add_attribute
+
+      def self.attribute(name, opts = {})
+        @attributes ||= {}
+
+        add_attribute(name, opts)
+      end
+
+      def self.attributes
+        @attributes
+      end
+    end
+  }
+
+  it "can add an attribute to a class" do
+    subject.class_eval do
+      attribute :foo, xpath: "bar", type: :baz
+    end
+
+    expected_attributes = {
+      foo: {xpath: "bar", type: :baz}
+    }
+
+    subject.attributes.should eq expected_attributes
+  end
+
+  it "raises an error if an attribute is defined more than once" do
+    expect {
+      subject.class_eval do
+        attribute :foo, xpath: "bar", type: :baz
+        attribute :foo, xpath: "bar", type: :baz
+      end
+    }.to raise_error(RuntimeError, /defined more than once/)
+  end
+
+  it "raises an error if the xpath is not specified" do
+    expect {
+      subject.class_eval do
+        attribute :foo, type: :baz
+      end
+    }.to raise_error(RuntimeError, /xpath(?:.*?)not specified/)
+  end
+end

--- a/spec/helpers/define_attribute_method_spec.rb
+++ b/spec/helpers/define_attribute_method_spec.rb
@@ -1,0 +1,110 @@
+describe Greeve::Helpers::DefineAttributeMethod do
+  let(:xml_double) {
+    double.tap do |d|
+      allow(d).to receive(:locate) { [value] }
+    end
+  }
+
+  let(:instance) { klass.new(xml_double) }
+  let(:attribute_name) { :foo }
+
+  subject { instance.send(attribute_name) }
+
+  shared_examples :test_attribute_types do
+    describe "integer attribute" do
+      let(:value) { "3" }
+      let(:expected) { 3 }
+
+      include_examples :can_define_an_attribute, :integer, Fixnum
+    end
+
+    describe "numeric attribute" do
+      let(:value) { "3.1" }
+      let(:expected) { BigDecimal.new("3.1") }
+
+      include_examples :can_define_an_attribute, :numeric, BigDecimal
+    end
+
+    describe "string attribute" do
+      let(:value) { "3" }
+      let(:expected) { "3" }
+
+      include_examples :can_define_an_attribute, :string, String
+    end
+
+    describe "datetime attribute" do
+      let(:value) { "2016-07-24 02:57:00" }
+      let(:expected) { Time.parse("2016-07-24 02:57:00 UTC") }
+
+      include_examples :can_define_an_attribute, :datetime, Time
+    end
+  end
+
+  context "class" do
+    let(:klass) {
+      Class.new do
+        extend Greeve::Helpers::DefineAttributeMethod
+
+        def self.attribute(name, opts = {})
+          define_attribute_method(:class, name, opts)
+        end
+
+        def initialize(xml_element)
+          @xml_element = xml_element
+        end
+      end
+    }
+
+    shared_examples :can_define_an_attribute do |attribute_type, attribute_class|
+      describe "can define an attribute of type #{attribute_type}" do
+        specify do
+          _attribute_name = attribute_name
+          _attribute_type = attribute_type
+
+          klass.instance_eval do
+            attribute _attribute_name, xpath: "testPath", type: _attribute_type
+          end
+
+          subject.should be_a attribute_class
+          subject.should eq expected
+        end
+      end
+    end
+
+    include_examples :test_attribute_types
+  end
+
+  context "instance" do
+    let(:klass) {
+      Class.new do
+        include Greeve::Helpers::DefineAttributeMethod
+
+        def attribute(name, opts = {})
+          define_attribute_method(:instance, name, opts)
+        end
+
+        def initialize(xml_element)
+          @xml_element = xml_element
+        end
+      end
+    }
+
+    shared_examples :can_define_an_attribute do |attribute_type, attribute_class|
+      describe "can define an attribute of type #{attribute_type}" do
+        specify do
+          _attribute_name = attribute_name
+          _attribute_type = attribute_type
+
+          instance.instance_eval do
+            attribute _attribute_name, xpath: "testPath", type: _attribute_type
+          end
+
+          subject.should be_a attribute_class
+          subject.should eq expected
+        end
+      end
+    end
+
+    include_examples :test_attribute_types
+  end
+end


### PR DESCRIPTION
For #4.

This PR abstracts out some of the code shared between `BaseItem`, `Row`, and `Rowset`, reducing code duplication and making the code easier to test.
