### PR TITLE
Remove unnecessary constructors

### DIFF
--- a/lib/greeve/api/call_list.rb
+++ b/lib/greeve/api/call_list.rb
@@ -22,10 +22,6 @@ module Greeve
         attribute :group_id,    xpath: "@groupID",     type: :integer
         attribute :description, xpath: "@description", type: :string
       end
-
-      def initialize(opts = {})
-        super(opts)
-      end
     end
   end
 end

--- a/lib/greeve/map/fac_war_systems.rb
+++ b/lib/greeve/map/fac_war_systems.rb
@@ -21,10 +21,6 @@ module Greeve
         attribute :victory_points,          xpath: "@victoryPoints",         type: :integer
         attribute :victory_point_threshold, xpath: "@victoryPointThreshold", type: :integer
       end
-
-      def initialize(opts = {})
-        super(opts)
-      end
     end
   end
 end

--- a/lib/greeve/map/jumps.rb
+++ b/lib/greeve/map/jumps.rb
@@ -14,10 +14,6 @@ module Greeve
         attribute :solar_system_id, xpath: "@solarSystemID", type: :integer
         attribute :ship_jumps,      xpath: "@shipJumps",     type: :integer
       end
-
-      def initialize(opts = {})
-        super(opts)
-      end
     end
   end
 end

--- a/lib/greeve/map/kills.rb
+++ b/lib/greeve/map/kills.rb
@@ -16,10 +16,6 @@ module Greeve
         attribute :faction_kills,   xpath: "@factionKills",  type: :integer
         attribute :pod_kills,       xpath: "@podKills",      type: :integer
       end
-
-      def initialize(opts = {})
-        super(opts)
-      end
     end
   end
 end

--- a/lib/greeve/map/sovereignty.rb
+++ b/lib/greeve/map/sovereignty.rb
@@ -16,10 +16,6 @@ module Greeve
         attribute :corporation_id,    xpath: "@corporationID",   type: :integer
         attribute :solar_system_name, xpath: "@solarSystemName", type: :string
       end
-
-      def initialize(opts = {})
-        super(opts)
-      end
     end
   end
 end

--- a/lib/greeve/server/server_status.rb
+++ b/lib/greeve/server/server_status.rb
@@ -10,10 +10,6 @@ module Greeve
 
       attribute :server_open,    xpath: "eveapi/result/serverOpen/?[0]",    type: :boolean
       attribute :online_players, xpath: "eveapi/result/onlinePlayers/?[0]", type: :integer
-
-      def initialize(opts = {})
-        super(opts)
-      end
     end
   end
 end


### PR DESCRIPTION
This PR removes the unnecessary `initialize` methods in some of the resources. By default the params are passed to `super`, so there's no reason to implement `initialize` in these cases.
