### PR TITLE
Refactor HTTP response error

### DIFF
--- a/lib/greeve.rb
+++ b/lib/greeve.rb
@@ -7,6 +7,7 @@ require_relative "greeve/version"
 require_relative "greeve/helpers/add_attribute"
 require_relative "greeve/helpers/define_attribute_method"
 
+require_relative "greeve/response_error"
 require_relative "greeve/base_item"
 require_relative "greeve/row"
 require_relative "greeve/rowset"

--- a/lib/greeve/base_item.rb
+++ b/lib/greeve/base_item.rb
@@ -1,6 +1,7 @@
 require "bigdecimal"
 require "time"
 
+require_relative "response_error"
 require_relative "helpers/add_attribute"
 require_relative "helpers/define_attribute_method"
 require_relative "rowset"
@@ -197,9 +198,10 @@ module Greeve
       url = "#{Greeve::EVE_API_BASE_URL}/#{endpoint}.xml.aspx"
       response = Typhoeus.get(url, params: @query_params)
 
-      # TODO: Use a better error class.
-      raise TypeError, "HTTP error #{response.code}" \
-        unless (200..299).include?(response.code.to_i)
+      raise ResponseError.new(
+        code: response.code,
+        status_message: response.status_message,
+      ) unless response.success?
 
       @xml_element = Ox.parse(response.body)
 

--- a/lib/greeve/response_error.rb
+++ b/lib/greeve/response_error.rb
@@ -1,0 +1,21 @@
+module Greeve
+  # HTTP response failed.
+  class ResponseError < StandardError
+    # HTTP error code
+    attr_reader :code
+    # HTTP error message
+    attr_reader :status_message
+
+    # @option opts [Integer] :code HTTP error code
+    # @option opts [String] :status_message HTTP error message
+    def initialize(opts = {})
+      @code = opts.fetch(:code).to_i
+      @status_message = opts.fetch(:status_message).dup.freeze
+    end
+
+    # @return [String] exception error message
+    def message
+      "#{@code} #{@status_message}"
+    end
+  end
+end

--- a/spec/base_item_spec.rb
+++ b/spec/base_item_spec.rb
@@ -8,6 +8,12 @@ vcr_opts_match_any = {
   allow_playback_repeats: true,
 }
 
+vcr_opts_response_error = {
+  cassette_name: "response_error_404",
+  match_requests_on: [],
+  allow_playback_repeats: true,
+}
+
 describe Greeve::BaseItem, vcr: vcr_opts do
   let(:character_id)  { 462421468 }
   let(:character_name) { "Zaphoon" }
@@ -37,6 +43,24 @@ describe Greeve::BaseItem, vcr: vcr_opts do
 
     let(:api_item) { subclass.new(character_id) }
     subject { api_item }
+
+    describe "ResponseError", vcr: vcr_opts_response_error do
+      subject {
+        begin
+          api_item
+        rescue Greeve::ResponseError => ex
+          ex
+        end
+      }
+
+      it "is raised" do
+        expect { api_item }.to raise_error(Greeve::ResponseError)
+      end
+
+      its(:code) { should eq 404 }
+      its(:status_message) { should eq "Not Found" }
+      its(:message) { should eq "404 Not Found" }
+    end
 
     describe "DSL" do
       let(:subclass) {

--- a/spec/cassettes/response_error_404.yml
+++ b/spec/cassettes/response_error_404.yml
@@ -1,0 +1,79 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.eveonline.com/test/error.xml.aspx
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - text/html; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.5
+      Access-Control-Allow-Origin:
+      - "*"
+      Date:
+      - Mon, 10 Oct 2016 02:58:54 GMT
+      Content-Length:
+      - '3621'
+    body:
+      encoding: UTF-8
+      string: "<!DOCTYPE html>\r\n<html>\r\n    <head>\r\n        <title>The resource
+        cannot be found.</title>\r\n        <meta name=\"viewport\" content=\"width=device-width\"
+        />\r\n        <style>\r\n         body {font-family:\"Verdana\";font-weight:normal;font-size:
+        .7em;color:black;} \r\n         p {font-family:\"Verdana\";font-weight:normal;color:black;margin-top:
+        -5px}\r\n         b {font-family:\"Verdana\";font-weight:bold;color:black;margin-top:
+        -5px}\r\n         H1 { font-family:\"Verdana\";font-weight:normal;font-size:18pt;color:red
+        }\r\n         H2 { font-family:\"Verdana\";font-weight:normal;font-size:14pt;color:maroon
+        }\r\n         pre {font-family:\"Consolas\",\"Lucida Console\",Monospace;font-size:11pt;margin:0;padding:0.5em;line-height:14pt}\r\n
+        \        .marker {font-weight: bold; color: black;text-decoration: none;}\r\n
+        \        .version {color: gray;}\r\n         .error {margin-bottom: 10px;}\r\n
+        \        .expandable { text-decoration:underline; font-weight:bold; color:navy;
+        cursor:hand; }\r\n         @media screen and (max-width: 639px) {\r\n          pre
+        { width: 440px; overflow: auto; white-space: pre-wrap; word-wrap: break-word;
+        }\r\n         }\r\n         @media screen and (max-width: 479px) {\r\n          pre
+        { width: 280px; }\r\n         }\r\n        </style>\r\n    </head>\r\n\r\n
+        \   <body bgcolor=\"white\">\r\n\r\n            <span><H1>Server Error in
+        '/' Application.<hr width=100% size=1 color=silver></H1>\r\n\r\n            <h2>
+        <i>The resource cannot be found.</i> </h2></span>\r\n\r\n            <font
+        face=\"Arial, Helvetica, Geneva, SunSans-Regular, sans-serif \">\r\n\r\n            <b>
+        Description: </b>HTTP 404. The resource you are looking for (or one of its
+        dependencies) could have been removed, had its name changed, or is temporarily
+        unavailable. &nbsp;Please review the following URL and make sure that it is
+        spelled correctly.\r\n            <br><br>\r\n\r\n            <b> Requested
+        URL: </b>/test/error.xml.aspx<br><br>\r\n\r\n            <hr width=100% size=1
+        color=silver>\r\n\r\n            <b>Version Information:</b>&nbsp;Microsoft
+        .NET Framework Version:4.0.30319; ASP.NET Version:4.0.30319.34274\r\n\r\n
+        \           </font>\r\n\r\n    </body>\r\n</html>\r\n<!-- \r\n[HttpException]:
+        The file &#39;/test/error.xml.aspx&#39; does not exist.\r\n   at System.Web.Compilation.BuildManager.GetVPathBuildResultInternal(VirtualPath
+        virtualPath, Boolean noBuild, Boolean allowCrossApp, Boolean allowBuildInPrecompile,
+        Boolean throwIfNotFound, Boolean ensureIsUpToDate)\r\n   at System.Web.Compilation.BuildManager.GetVPathBuildResultWithNoAssert(HttpContext
+        context, VirtualPath virtualPath, Boolean noBuild, Boolean allowCrossApp,
+        Boolean allowBuildInPrecompile, Boolean throwIfNotFound, Boolean ensureIsUpToDate)\r\n
+        \  at System.Web.Compilation.BuildManager.GetVirtualPathObjectFactory(VirtualPath
+        virtualPath, HttpContext context, Boolean allowCrossApp, Boolean throwIfNotFound)\r\n
+        \  at System.Web.Compilation.BuildManager.CreateInstanceFromVirtualPath(VirtualPath
+        virtualPath, Type requiredBaseType, HttpContext context, Boolean allowCrossApp)\r\n
+        \  at System.Web.UI.PageHandlerFactory.GetHandlerHelper(HttpContext context,
+        String requestType, VirtualPath virtualPath, String physicalPath)\r\n   at
+        System.Web.HttpApplication.MaterializeHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()\r\n
+        \  at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean&
+        completedSynchronously)\r\n--><!-- \r\nThis error page might contain sensitive
+        information because ASP.NET is configured to show verbose error messages using
+        &lt;customErrors mode=\"Off\"/&gt;. Consider using &lt;customErrors mode=\"On\"/&gt;
+        or &lt;customErrors mode=\"RemoteOnly\"/&gt; in production environments.-->"
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.eveonline.com/test/error.xml.aspx
+  recorded_at: Mon, 10 Oct 2016 02:58:54 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
This PR replaces the former generic HTTP response error class of `TypeError` with the custom class `ResponseError`. `TypeError` was used as a quick implementation when spiking the library as a proof of concept, and doesn't quite fit for the data we want to be able to inspect from a failed HTTP request. Therefore `ResponseError` was implemented as a more specific error type that provides a better interface for HTTP response errors.
