### PR TITLE
Endpoint helper no longer coerces the extension

### DIFF
--- a/lib/greeve/base_item.rb
+++ b/lib/greeve/base_item.rb
@@ -80,14 +80,16 @@ module Greeve
 
     # A DSL method to specify the API endpoint.
     #
-    # @param path [String] path of the API endpoint. Doesn't need to include the
+    # @param path [String] path of the API endpoint. It shouldn't include the
     #   leading slash `/`, or the extension `.xml.aspx`
     #
     # @example
     #   endpoint "eve/CharacterInfo"
     def self.endpoint(path)
-      # Remove leading slash and file extension.
-      @endpoint = path.gsub(/\A\/*(.*?)(?:\.xml)?(?:\.aspx)?\z/, '\1')
+      raise ArgumentError, "Endpoint shouldn't start with a slash" \
+        if path.start_with?("/")
+
+      @endpoint = path
     end
 
     # @abstract Subclass and use the DSL methods to map API endpoints to objects

--- a/spec/base_item_spec.rb
+++ b/spec/base_item_spec.rb
@@ -73,12 +73,22 @@ describe Greeve::BaseItem, vcr: vcr_opts do
         end
       }
 
-      specify "endpoint", vcr: vcr_opts_match_any do
-        subclass.class_eval do
-          endpoint "/test/endpoint.xml.aspx"
+      describe "endpoint", vcr: vcr_opts_match_any do
+        specify do
+          subclass.class_eval do
+            endpoint "test/endpoint"
+          end
+
+          subject.__send__(:endpoint).should eq "test/endpoint"
         end
 
-        subject.__send__(:endpoint).should eq "test/endpoint"
+        specify "shouldn't start with a slash" do
+          expect {
+            subclass.class_eval do
+              endpoint "/test/endpoint"
+            end
+          }.to raise_error ArgumentError
+        end
       end
 
       specify "attribute" do


### PR DESCRIPTION
This PR removes the `.xml.aspx` extension coercion from the `endpoint` DSL method, as well as removing coercion for the leading slash (`/`). This ensures that all endpoints follow the same style.
