### PR TITLE
Refactor Character::MailBodes to splat message_ids

### DIFF
--- a/lib/greeve/character/mail_bodies.rb
+++ b/lib/greeve/character/mail_bodies.rb
@@ -14,10 +14,12 @@ module Greeve
       end
 
       # @param character_id [Integer] EVE character ID
-      # @param message_ids [Array<Integer>, Integer] either a single message ID,
-      #   or an array of message IDs
-      def initialize(character_id, message_ids, opts = {})
-        message_ids = [message_ids] unless message_ids.is_a?(Array)
+      # @param message_ids [*Array<Integer>, Integer] either a single message ID,
+      #   or a list of message IDs
+      #
+      # @!method initialize(character_id, *message_ids, opts = {})
+      def initialize(character_id, *message_ids)
+        opts = message_ids.last.is_a?(Hash) ? message_ids.pop : {}
 
         opts[:query_params] = {
           "characterID" => character_id,

--- a/spec/character/mail_bodies_spec.rb
+++ b/spec/character/mail_bodies_spec.rb
@@ -34,6 +34,10 @@ describe Greeve::Character::MailBodies, vcr: vcr_opts do
   context "multiple message ids", vcr: vcr_opts_multiple_ids do
     let(:message_ids) { [362680073, 362680744] }
 
+    let(:resource) {
+      Greeve::Character::MailBodies.new(character_id, *message_ids, key: key, vcode: vcode)
+    }
+
     context "resource" do
       subject { resource }
 


### PR DESCRIPTION
This PR refactors the `message_ids` param to a splat, like in [`Corporation::Locations`](https://github.com/EVEolve/greeve/blob/55ba4116628304474f34c3c64154db98702ac629/lib/greeve/corporation/locations.rb#L21-L25).

For #55.